### PR TITLE
Attempt to fix Monaco editor issues

### DIFF
--- a/client/monaco_editor.js
+++ b/client/monaco_editor.js
@@ -37,6 +37,8 @@ export default class MonacoEditor {
                     language: 'javascript',
                     fontSize: 12,
                     theme: 'vs-dark',
+                    fixedOverflowWidgets: true,
+                    scrollBeyondLastLine: false,
                     ...monacoEditorConfig
                 });
 
@@ -70,19 +72,6 @@ export default class MonacoEditor {
                         },
                     ]);
                 }
-
-                // HACK: Force the Monaco editor to relayout after initialization
-                setTimeout(() => {
-                    MonacoEditor._instance.layout({});
-                }, 2000);
-
-                window.onresize = () => {
-                    MonacoEditor._instance.layout({});
-                };
-
-                window.onpageshow = () => {
-                    MonacoEditor._instance.layout({});
-                };
 
                 resolve();
             });

--- a/client/static/coderogue.css
+++ b/client/static/coderogue.css
@@ -58,5 +58,6 @@ span {
 
 #monaco-editor-container {
     min-height: 400px;
+    resize: vertical;
     overflow: auto;
 }

--- a/client/static/index.html
+++ b/client/static/index.html
@@ -101,10 +101,10 @@
                     <!-- Code tab -->
                     <div class="tab-pane active" id="code" role="tabpanel">
                         <div class="row">
-                            <div class="col">
+                            <div class="col-10">
                                 <div id="monaco-editor-container"></div>
                             </div>
-                            <div class="col-2">
+                            <div class="col">
                                 <div class="d-grid gap-2">
                                     <button type="button" class="btn btn-secondary" id="respawn1">Respawn</button>
                                     <button type="button" class="btn btn-secondary" id="reformat">Reformat</button>


### PR DESCRIPTION
Bootstrap's grid layout mechanism seems to be the culprit!

Previously the `Code` tab has the command buttons (Respawn/Reformat/Submit) occupy 2 out of 12 in width (Bootstrap by default assumes 12 columns per row), and the Monaco editor would automatically resize. But somehow this has created problems to the Monaco editor - inconsistent resizing, mysteriously disappearing, etc.

After some poking around, I realized switching to fix the Monaco editor's width to be 10 out of 12 and let the buttons auto resize could perfectly solve the problem. We don't need any hacks like onresize, onpageshow, setTimeout hacks!

I verified in Edge browser and it worked pretty smoothly. Please give it a try when you get a chance and see if it works for you as well.